### PR TITLE
Pin workflow actions to SHA hashes for security

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,7 +29,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can
       # access it
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
   scan-scheduled:
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.2"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@2a387edfbe02a11d856b89172f6e978100177eb4" # v2.3.2


### PR DESCRIPTION
Replace mutable tag/branch references with immutable SHA hashes
to prevent unexpected changes from upstream action updates:
- actions/checkout@main -> @0c366fd6a839edf440554fa01a7085ccba70ac98
- google/osv-scanner-action@v2.3.2 -> @2a387edfbe02a11d856b89172f6e978100177eb4

https://claude.ai/code/session_01Fdfaxa6bNssdrCJToPmXMM